### PR TITLE
Various updates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ html_includes=(
   '--include-before-body=templates/body-open.html'
   '--include-after-body=templates/body-close.html'
   '--include-after-body=templates/js-imports.html'
-  '--include-after-body=templates/script.html'
+  '--include-after-body=build/script.html'
   '--latexmathml'
 );
 
@@ -102,6 +102,8 @@ for idx in "${!outputs[@]}"; do
       > build/toolbox.md;
     mv build/toolbox.md build/toolbox_raw.md;
   elif [ "$format" = "-t html" ]; then 
+    GIT_COMMIT_DATE=$(bash -c "git log -1 --format=%cD | cut -f1-4 -d ' '")
+    sed "s|LASTCOMMITDATE|$GIT_COMMIT_DATE|g" ./templates/script.html > build/script.html
     cat build/toolbox_raw.md |\
       sed -e 's|\\ref{\([^}]*\)}|<span class="ref">\1</span>|g' \
       > build/toolbox.md;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y \
+        git \
+        pandoc \
+        pandoc-citeproc \
+        texlive-fonts-recommended \
+        texlive-latex-extra \
+        texlive-fonts-extra \
+        python-pip \
+        && pip install pandoc-fignos --system

--- a/natcap_build.sh
+++ b/natcap_build.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+# Generate the html file at build/toolbox.html
+./build.sh --html --nospellcheck
+
+# fix up relative paths so we can distribute to bucket
+sed 's|../images|images|g' build/toolbox.html > build/index.html
+
+# Synchronize the toolbox with the storage bucket.
+# Assumes we're properly authenticated with google cloud/gsutil.
+gsutil cp build/index.html gs://viz.naturalcapitalproject.org/index.html
+gsutil -m rsync -d images gs://viz.naturalcapitalproject.org/images

--- a/templates/script.html
+++ b/templates/script.html
@@ -16,12 +16,6 @@ toc.addClass("side-nav").addClass("fixed");
 // Add link to live demo & title of project
 const masterpageUrl = 'http://www.charlotteweil.fr/masterthesis';
 toc.prepend(
-    '<li>' + 
-    '<a href="toolbox.pdf" target="_blank">' +
-    '<i class="material-icons">picture_as_pdf</i> PDF version' +
-    '</a>' +
-    '</li>' +
-    '<div class="bottom divider"></div>' + 
     '<li>' +
     '<a class="title" href="#title">' +
     titleFirst +

--- a/templates/script.html
+++ b/templates/script.html
@@ -15,6 +15,9 @@ toc.addClass("side-nav").addClass("fixed");
 
 // Add link to live demo & title of project
 const masterpageUrl = 'http://www.charlotteweil.fr/masterthesis';
+
+// Note the date last updated, taken from git during the build process and inserted here.
+const lastUpdated = 'LASTCOMMITDATE'
 toc.prepend(
     '<li>' +
     '<a class="title" href="#title">' +
@@ -24,7 +27,6 @@ toc.prepend(
 
 // Add link to pdf document
 toc.append(
-    
     '<div class="divider"></div>' +
     '<li>' + 
     '<a href="' + masterpageUrl + '">' +
@@ -33,7 +35,7 @@ toc.append(
     '<div class="bottom divider"></div>' +
     '<li>' + 
     '<a href="' + masterpageUrl + '">' +
-    '<i class="material-icons">schedule</i> Updated Nov. 2017' +
+    '<i class="material-icons">schedule</i> Updated ' + lastUpdated +
     '</a>' +
     '</li>');
 


### PR DESCRIPTION
This PR touches up a couple things that we chatted about recently.  Notable changes include:

* The date of the last commit is included in the HTML build at build time
* Natcap-specific build stuff is stored in a new build script, `natcap_build.sh`
* I've disabled the PDF build for the time being, since I'm about to do an infrastructure overhaul on our end.  Our current infrastructure won't allow the PDF build without a major system upgrade, so I'd like to include the PDF docs in the build once this overhaul is finished.

There's also a `Dockerfile` in there, at `docker/Dockerfile`, but this isn't used yet by the build.  It's there mostly for reference, in case someone wants a semi-standardized build system for assembling the docs.

Once this is merged, I'll touch up the automatic builds on the build server and then the last thing we'll need to do is set up the webhook so that when someone pushes to your repo, the build is triggered.

Let me know what you think about this!